### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '3.8.4'
+gem 'jekyll', '~> 3.9'
 
 group :jekyll_plugins do
-  gem 'jekyll-paginate'
-  gem 'jekyll-sitemap'
+  gem 'jekyll-paginate', '0.15.1'
+  gem 'jekyll-sitemap', '1.4.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 3.9'
+gem 'kramdown-parser-gfm', '~> 1.1'
+gem 'webrick', '~> 1.7'
 
 group :jekyll_plugins do
-  gem 'jekyll-paginate', '0.15.1'
-  gem 'jekyll-sitemap', '1.4.0'
+  gem 'jekyll-paginate', '~> 0.15.1'
+  gem 'jekyll-sitemap', '~> 1.4.0'
 end


### PR DESCRIPTION
I've updated the Gemfile to match the environment specified by GH Pages here

https://pages.github.com/versions/

I also added webrick to support Ruby 3 and the kramdown parser which is needed for Jekyll 3.9 (it wasn't needed for 3.8 or for 4)

You'll need to delete Gemfile.lock and create it again with `bundle install` and then commit that